### PR TITLE
WIP: Fix: Update Caddy download URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ default['caddy']['features'] = []
 default['caddy']['email'] = nil
 default['caddy']['hosts'] = {}
 default['caddy']['ulimit'] = 8192
-default['caddy']['ark']['url'] = "https://caddyserver.com/download/build?os=linux&arch=amd64&features=#{node['caddy']['features'].join(',')}"
+default['caddy']['ark']['url'] = "https://caddyserver.com/download/linux/amd64?#{node['caddy']['features'].join(',')}"
 default['caddy']['ark']['extension'] = 'tar.gz'
 default['caddy']['ark']['binary_name'] = 'caddy'
 default['caddy']['ark']['binaries'] = ["./#{node['caddy']['ark']['binary_name']}"]


### PR DESCRIPTION
The download URL has changed, meaning that the cookbook currently fails.
This updates it to the latest version of the URL.

Luckily this is made configurable by your changes, but this fix will
ensure that new users of the cookbook need not override the attributes
on their own machines.